### PR TITLE
Updated requirements.txt and README.md 

### DIFF
--- a/Minecpp/requirements.txt
+++ b/Minecpp/requirements.txt
@@ -3,6 +3,7 @@ code_bert_score==0.4.1
 crystalbleu==0.1
 lizard==1.17.10
 nltk==3.9
+numpy==1.26.4
 pandas==2.0.3
 PyDriller==2.6
 torch==2.2.0

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ The tool also provides a GUI to explore and analyse the dataset. It provides two
 ## Configuration
 
 ```
-Python 3.8 or above
+Python version above 3.8 and below 3.11
 Needs C++ 14
 ```
 


### PR DESCRIPTION
Python 3.12 doesn't support torch==2.1.2, required while installation.
Pandas while installation installs latest version of numpy but the newer versions of numpy are not supported. 